### PR TITLE
Remove Lombok, add explicit POJOs & Java 21

### DIFF
--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,26 +1,26 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { useI18n, type LangCode } from '@/i18n';
+import { CHAT_SUGGESTIONS, CHAT_SUGGESTIONS_SI, CHAT_SUGGESTIONS_TA, GOV_SERVICES, LANGUAGES } from '@/lib/constants';
+import { AnimatePresence, motion } from 'framer-motion';
 import {
-  Send,
-  Sparkles,
-  Newspaper,
-  BookOpen,
-  CreditCard,
-  CloudSun,
-  Landmark,
-  Building2,
-  Bot,
-  User,
   ArrowRight,
   BadgeCheck,
+  BookOpen,
+  Bot,
+  Building2,
+  CloudSun,
+  CreditCard,
   ExternalLink,
+  Landmark,
   Mic,
   MicOff,
+  Newspaper,
+  Send,
+  Sparkles,
+  User,
 } from 'lucide-react';
-import { CHAT_SUGGESTIONS, CHAT_SUGGESTIONS_SI, CHAT_SUGGESTIONS_TA, LANGUAGES, GOV_SERVICES } from '@/lib/constants';
-import { useI18n, type LangCode } from '@/i18n';
+import { useEffect, useRef, useState } from 'react';
 
 const iconMap: Record<string, any> = {
   Newspaper, BookOpen, CreditCard, CloudSun, Landmark, Building2,
@@ -236,16 +236,13 @@ export default function ChatPage() {
               animate={{ opacity: 1, y: 0 }}
               className="text-center py-16"
             >
-              <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center mx-auto mb-6 shadow-lg shadow-brand-500/25">
-                <Sparkles size={28} className="text-white" />
-              </div>
+            
               <h2 className="font-display text-2xl font-bold text-white mb-2">
                 {t.chat.welcomeTitle} <span className="gradient-text">Infora</span>
               </h2>
               <p className="text-white/40 mb-10 max-w-md mx-auto">
                 {t.chat.welcomeSubtitle}
               </p>
-
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-lg mx-auto">
                 {suggestions.map((s) => {
                   const Icon = iconMap[s.icon] || Sparkles;

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -21,7 +21,7 @@
 
     <!-- ─── Properties ─── -->
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <firebase-admin.version>9.3.0</firebase-admin.version>
         <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
         <jjwt.version>0.12.5</jjwt.version>
@@ -127,13 +127,6 @@
              Developer Productivity
              ══════════════════════════════════════════════ -->
 
-        <!-- Lombok — reduces boilerplate (@Data, @Builder, @Slf4j) -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
-
         <!-- DevTools — live reload during development -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -163,16 +156,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/backend/src/main/java/com/infora/backend/config/FirebaseAuthFilter.java
+++ b/backend/src/main/java/com/infora/backend/config/FirebaseAuthFilter.java
@@ -6,8 +6,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -20,12 +20,16 @@ import java.io.IOException;
  * Currently in permissive mode — logs warnings but allows requests through.
  * To enforce auth: return 401 when token is missing/invalid.
  */
-@Slf4j
 @Component
-@RequiredArgsConstructor
 public class FirebaseAuthFilter extends OncePerRequestFilter {
 
+    private static final Logger log = LoggerFactory.getLogger(FirebaseAuthFilter.class);
+
     private final FirebaseAuth firebaseAuth;
+
+    public FirebaseAuthFilter(FirebaseAuth firebaseAuth) {
+        this.firebaseAuth = firebaseAuth;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/backend/src/main/java/com/infora/backend/config/FirebaseConfig.java
+++ b/backend/src/main/java/com/infora/backend/config/FirebaseConfig.java
@@ -8,7 +8,8 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.cloud.FirestoreClient;
 import com.google.firebase.cloud.StorageClient;
 import jakarta.annotation.PostConstruct;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,29 +21,36 @@ import java.io.IOException;
  * Initializes the Firebase Admin SDK and exposes Firestore, FirebaseAuth,
  * and StorageClient as Spring-managed beans.
  *
- * Requires a service account JSON key file — path set via:
- *   FIREBASE_SERVICE_ACCOUNT_KEY (env variable) or
- *   firebase.service-account-key (application.properties)
+ * Handles DevTools restarts properly by cleaning up stale Firebase instances.
  */
-@Slf4j
 @Configuration
 public class FirebaseConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(FirebaseConfig.class);
 
     @Value("${firebase.service-account-key:src/main/resources/firebase-service-account.json}")
     private String serviceAccountKeyPath;
 
     @PostConstruct
     public void initFirebase() throws IOException {
-        if (FirebaseApp.getApps().isEmpty()) {
-            FileInputStream serviceAccount = new FileInputStream(serviceAccountKeyPath);
-
-            FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                    .build();
-
-            FirebaseApp.initializeApp(options);
-            log.info("✅ Firebase Admin SDK initialized successfully");
+        // Clean up any existing FirebaseApp (handles DevTools restart)
+        if (!FirebaseApp.getApps().isEmpty()) {
+            log.info("Cleaning up existing Firebase instance (DevTools restart detected)");
+            try {
+                FirebaseApp.getInstance().delete();
+            } catch (Exception e) {
+                log.debug("Firebase cleanup: {}", e.getMessage());
+            }
         }
+
+        FileInputStream serviceAccount = new FileInputStream(serviceAccountKeyPath);
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        FirebaseApp.initializeApp(options);
+        log.info("✅ Firebase Admin SDK initialized successfully");
     }
 
     @Bean

--- a/backend/src/main/java/com/infora/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/infora/backend/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 /**
  * Spring Security configuration.
@@ -15,13 +16,16 @@ import org.springframework.security.web.SecurityFilterChain;
  *  - CSRF disabled (stateless REST API)
  *  - Sessions disabled (stateless)
  *  - All endpoints permitted (TODO: add Firebase token filter)
- *
- * In a future iteration, a custom Firebase Authentication filter
- * should be added to verify ID tokens on protected endpoints.
  */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final CorsConfigurationSource corsConfigurationSource;
+
+    public SecurityConfig(CorsConfigurationSource corsConfigurationSource) {
+        this.corsConfigurationSource = corsConfigurationSource;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -29,8 +33,7 @@ public class SecurityConfig {
             .csrf(AbstractHttpConfigurer::disable)
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .cors(cors -> cors.configurationSource(
-                new CorsConfig().corsConfigurationSource()))
+            .cors(cors -> cors.configurationSource(corsConfigurationSource))
             .authorizeHttpRequests(auth -> auth
                 // Public endpoints
                 .requestMatchers(

--- a/backend/src/main/java/com/infora/backend/controller/ChatController.java
+++ b/backend/src/main/java/com/infora/backend/controller/ChatController.java
@@ -8,7 +8,6 @@ import com.infora.backend.service.ChatService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,11 +15,14 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/chat")
-@RequiredArgsConstructor
 @Tag(name = "Chat", description = "Conversational AI chat endpoints")
 public class ChatController {
 
     private final ChatService chatService;
+
+    public ChatController(ChatService chatService) {
+        this.chatService = chatService;
+    }
 
     @PostMapping
     @Operation(summary = "Send a message and get AI response")

--- a/backend/src/main/java/com/infora/backend/controller/GovServiceController.java
+++ b/backend/src/main/java/com/infora/backend/controller/GovServiceController.java
@@ -5,7 +5,6 @@ import com.infora.backend.model.GovService;
 import com.infora.backend.service.GovServiceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,11 +12,14 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/services")
-@RequiredArgsConstructor
 @Tag(name = "Government Services", description = "Government service guidance endpoints")
 public class GovServiceController {
 
     private final GovServiceService govServiceService;
+
+    public GovServiceController(GovServiceService govServiceService) {
+        this.govServiceService = govServiceService;
+    }
 
     @GetMapping
     @Operation(summary = "Get all government services")

--- a/backend/src/main/java/com/infora/backend/controller/NewsController.java
+++ b/backend/src/main/java/com/infora/backend/controller/NewsController.java
@@ -6,7 +6,6 @@ import com.infora.backend.service.NewsService;
 import com.infora.backend.service.NewsScraperService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,12 +13,16 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/news")
-@RequiredArgsConstructor
 @Tag(name = "News", description = "News retrieval endpoints")
 public class NewsController {
 
     private final NewsService newsService;
     private final NewsScraperService newsScraperService;
+
+    public NewsController(NewsService newsService, NewsScraperService newsScraperService) {
+        this.newsService = newsService;
+        this.newsScraperService = newsScraperService;
+    }
 
     @GetMapping
     @Operation(summary = "Get latest news articles")

--- a/backend/src/main/java/com/infora/backend/controller/UserController.java
+++ b/backend/src/main/java/com/infora/backend/controller/UserController.java
@@ -7,7 +7,6 @@ import com.infora.backend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,11 +14,14 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/users")
-@RequiredArgsConstructor
 @Tag(name = "Users", description = "User management endpoints")
 public class UserController {
 
     private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
 
     @PostMapping("/{userId}")
     @Operation(summary = "Create or update a user profile")

--- a/backend/src/main/java/com/infora/backend/dto/ApiResponse.java
+++ b/backend/src/main/java/com/infora/backend/dto/ApiResponse.java
@@ -1,40 +1,34 @@
 package com.infora.backend.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class ApiResponse<T> {
     private boolean success;
     private String message;
     private T data;
 
+    public ApiResponse() {}
+
+    public ApiResponse(boolean success, String message, T data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    public boolean isSuccess() { return success; }
+    public void setSuccess(boolean success) { this.success = success; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public T getData() { return data; }
+    public void setData(T data) { this.data = data; }
+
     public static <T> ApiResponse<T> ok(T data) {
-        return ApiResponse.<T>builder()
-                .success(true)
-                .message("OK")
-                .data(data)
-                .build();
+        return new ApiResponse<>(true, "OK", data);
     }
 
     public static <T> ApiResponse<T> ok(String message, T data) {
-        return ApiResponse.<T>builder()
-                .success(true)
-                .message(message)
-                .data(data)
-                .build();
+        return new ApiResponse<>(true, message, data);
     }
 
     public static <T> ApiResponse<T> error(String message) {
-        return ApiResponse.<T>builder()
-                .success(false)
-                .message(message)
-                .data(null)
-                .build();
+        return new ApiResponse<>(false, message, null);
     }
 }

--- a/backend/src/main/java/com/infora/backend/dto/ChatRequest.java
+++ b/backend/src/main/java/com/infora/backend/dto/ChatRequest.java
@@ -1,21 +1,27 @@
 package com.infora.backend.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class ChatRequest {
     @NotBlank(message = "Message content is required")
     private String message;
 
     private String sessionId;
 
-    @Builder.Default
     private String language = "en"; // "en", "si", "ta"
+
+    public ChatRequest() {}
+
+    public ChatRequest(String message, String sessionId, String language) {
+        this.message = message;
+        this.sessionId = sessionId;
+        this.language = language;
+    }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public String getSessionId() { return sessionId; }
+    public void setSessionId(String sessionId) { this.sessionId = sessionId; }
+    public String getLanguage() { return language; }
+    public void setLanguage(String language) { this.language = language; }
 }

--- a/backend/src/main/java/com/infora/backend/dto/ChatResponse.java
+++ b/backend/src/main/java/com/infora/backend/dto/ChatResponse.java
@@ -1,26 +1,29 @@
 package com.infora.backend.dto;
 
 import com.infora.backend.model.Message;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class ChatResponse {
     private String sessionId;
     private Message reply;
     private List<ResponseCard> cards;
 
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
+    public ChatResponse() {}
+
+    public ChatResponse(String sessionId, Message reply, List<ResponseCard> cards) {
+        this.sessionId = sessionId;
+        this.reply = reply;
+        this.cards = cards;
+    }
+
+    public String getSessionId() { return sessionId; }
+    public void setSessionId(String sessionId) { this.sessionId = sessionId; }
+    public Message getReply() { return reply; }
+    public void setReply(Message reply) { this.reply = reply; }
+    public List<ResponseCard> getCards() { return cards; }
+    public void setCards(List<ResponseCard> cards) { this.cards = cards; }
+
     public static class ResponseCard {
         private String title;
         private String description;
@@ -28,5 +31,29 @@ public class ChatResponse {
         private String source;
         private String sourceUrl;
         private boolean verified;
+
+        public ResponseCard() {}
+
+        public ResponseCard(String title, String description, String type, String source, String sourceUrl, boolean verified) {
+            this.title = title;
+            this.description = description;
+            this.type = type;
+            this.source = source;
+            this.sourceUrl = sourceUrl;
+            this.verified = verified;
+        }
+
+        public String getTitle() { return title; }
+        public void setTitle(String title) { this.title = title; }
+        public String getDescription() { return description; }
+        public void setDescription(String description) { this.description = description; }
+        public String getType() { return type; }
+        public void setType(String type) { this.type = type; }
+        public String getSource() { return source; }
+        public void setSource(String source) { this.source = source; }
+        public String getSourceUrl() { return sourceUrl; }
+        public void setSourceUrl(String sourceUrl) { this.sourceUrl = sourceUrl; }
+        public boolean isVerified() { return verified; }
+        public void setVerified(boolean verified) { this.verified = verified; }
     }
 }

--- a/backend/src/main/java/com/infora/backend/dto/UserRequest.java
+++ b/backend/src/main/java/com/infora/backend/dto/UserRequest.java
@@ -2,15 +2,7 @@ package com.infora.backend.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class UserRequest {
     @NotBlank(message = "Name is required")
     private String name;
@@ -19,6 +11,20 @@ public class UserRequest {
     @Email(message = "Invalid email format")
     private String email;
 
-    @Builder.Default
     private String preferredLanguage = "en";
+
+    public UserRequest() {}
+
+    public UserRequest(String name, String email, String preferredLanguage) {
+        this.name = name;
+        this.email = email;
+        this.preferredLanguage = preferredLanguage;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPreferredLanguage() { return preferredLanguage; }
+    public void setPreferredLanguage(String preferredLanguage) { this.preferredLanguage = preferredLanguage; }
 }

--- a/backend/src/main/java/com/infora/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/infora/backend/exception/GlobalExceptionHandler.java
@@ -1,7 +1,8 @@
 package com.infora.backend.exception;
 
 import com.infora.backend.dto.ApiResponse;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -10,9 +11,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.stream.Collectors;
 
-@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleNotFound(ResourceNotFoundException ex) {

--- a/backend/src/main/java/com/infora/backend/model/ChatSession.java
+++ b/backend/src/main/java/com/infora/backend/model/ChatSession.java
@@ -1,24 +1,38 @@
 package com.infora.backend.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class ChatSession {
     private String id;
     private String userId;
     private String language; // "en", "si", "ta"
-    @Builder.Default
     private List<Message> messages = new ArrayList<>();
     private Instant createdAt;
     private Instant updatedAt;
+
+    public ChatSession() {}
+
+    public ChatSession(String id, String userId, String language, List<Message> messages, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.language = language;
+        this.messages = messages != null ? messages : new ArrayList<>();
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getUserId() { return userId; }
+    public void setUserId(String userId) { this.userId = userId; }
+    public String getLanguage() { return language; }
+    public void setLanguage(String language) { this.language = language; }
+    public List<Message> getMessages() { return messages; }
+    public void setMessages(List<Message> messages) { this.messages = messages; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+    public Instant getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
 }

--- a/backend/src/main/java/com/infora/backend/model/GovService.java
+++ b/backend/src/main/java/com/infora/backend/model/GovService.java
@@ -1,16 +1,7 @@
 package com.infora.backend.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.List;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class GovService {
     private String id;
     private String nameEn;
@@ -27,4 +18,55 @@ public class GovService {
     private String officialUrl;
     private List<String> documents;
     private List<String> steps;
+
+    public GovService() {}
+
+    public GovService(String id, String nameEn, String nameSi, String nameTa, String descriptionEn, String descriptionSi, String descriptionTa, String icon, String color, String processingTime, String fee, String officialSource, String officialUrl, List<String> documents, List<String> steps) {
+        this.id = id;
+        this.nameEn = nameEn;
+        this.nameSi = nameSi;
+        this.nameTa = nameTa;
+        this.descriptionEn = descriptionEn;
+        this.descriptionSi = descriptionSi;
+        this.descriptionTa = descriptionTa;
+        this.icon = icon;
+        this.color = color;
+        this.processingTime = processingTime;
+        this.fee = fee;
+        this.officialSource = officialSource;
+        this.officialUrl = officialUrl;
+        this.documents = documents;
+        this.steps = steps;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getNameEn() { return nameEn; }
+    public void setNameEn(String nameEn) { this.nameEn = nameEn; }
+    public String getNameSi() { return nameSi; }
+    public void setNameSi(String nameSi) { this.nameSi = nameSi; }
+    public String getNameTa() { return nameTa; }
+    public void setNameTa(String nameTa) { this.nameTa = nameTa; }
+    public String getDescriptionEn() { return descriptionEn; }
+    public void setDescriptionEn(String descriptionEn) { this.descriptionEn = descriptionEn; }
+    public String getDescriptionSi() { return descriptionSi; }
+    public void setDescriptionSi(String descriptionSi) { this.descriptionSi = descriptionSi; }
+    public String getDescriptionTa() { return descriptionTa; }
+    public void setDescriptionTa(String descriptionTa) { this.descriptionTa = descriptionTa; }
+    public String getIcon() { return icon; }
+    public void setIcon(String icon) { this.icon = icon; }
+    public String getColor() { return color; }
+    public void setColor(String color) { this.color = color; }
+    public String getProcessingTime() { return processingTime; }
+    public void setProcessingTime(String processingTime) { this.processingTime = processingTime; }
+    public String getFee() { return fee; }
+    public void setFee(String fee) { this.fee = fee; }
+    public String getOfficialSource() { return officialSource; }
+    public void setOfficialSource(String officialSource) { this.officialSource = officialSource; }
+    public String getOfficialUrl() { return officialUrl; }
+    public void setOfficialUrl(String officialUrl) { this.officialUrl = officialUrl; }
+    public List<String> getDocuments() { return documents; }
+    public void setDocuments(List<String> documents) { this.documents = documents; }
+    public List<String> getSteps() { return steps; }
+    public void setSteps(List<String> steps) { this.steps = steps; }
 }

--- a/backend/src/main/java/com/infora/backend/model/Message.java
+++ b/backend/src/main/java/com/infora/backend/model/Message.java
@@ -1,21 +1,33 @@
 package com.infora.backend.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.time.Instant;
 import java.util.Map;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class Message {
     private String role;       // "user", "assistant", "system"
     private String content;
     private String type;       // "text", "card", "step", "link"
     private Instant timestamp;
     private Map<String, Object> metadata;
+
+    public Message() {}
+
+    public Message(String role, String content, String type, Instant timestamp, Map<String, Object> metadata) {
+        this.role = role;
+        this.content = content;
+        this.type = type;
+        this.timestamp = timestamp;
+        this.metadata = metadata;
+    }
+
+    public String getRole() { return role; }
+    public void setRole(String role) { this.role = role; }
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+    public Instant getTimestamp() { return timestamp; }
+    public void setTimestamp(Instant timestamp) { this.timestamp = timestamp; }
+    public Map<String, Object> getMetadata() { return metadata; }
+    public void setMetadata(Map<String, Object> metadata) { this.metadata = metadata; }
 }

--- a/backend/src/main/java/com/infora/backend/model/NewsArticle.java
+++ b/backend/src/main/java/com/infora/backend/model/NewsArticle.java
@@ -1,16 +1,7 @@
 package com.infora.backend.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.time.Instant;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class NewsArticle {
     private String id;
     private String titleEn;
@@ -25,4 +16,49 @@ public class NewsArticle {
     private String district;
     private String category;
     private boolean verified;
+
+    public NewsArticle() {}
+
+    public NewsArticle(String id, String titleEn, String titleSi, String summaryEn, String summarySi, String source, String sourceUrl, String url, String imageUrl, Instant publishedAt, String district, String category, boolean verified) {
+        this.id = id;
+        this.titleEn = titleEn;
+        this.titleSi = titleSi;
+        this.summaryEn = summaryEn;
+        this.summarySi = summarySi;
+        this.source = source;
+        this.sourceUrl = sourceUrl;
+        this.url = url;
+        this.imageUrl = imageUrl;
+        this.publishedAt = publishedAt;
+        this.district = district;
+        this.category = category;
+        this.verified = verified;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getTitleEn() { return titleEn; }
+    public void setTitleEn(String titleEn) { this.titleEn = titleEn; }
+    public String getTitleSi() { return titleSi; }
+    public void setTitleSi(String titleSi) { this.titleSi = titleSi; }
+    public String getSummaryEn() { return summaryEn; }
+    public void setSummaryEn(String summaryEn) { this.summaryEn = summaryEn; }
+    public String getSummarySi() { return summarySi; }
+    public void setSummarySi(String summarySi) { this.summarySi = summarySi; }
+    public String getSource() { return source; }
+    public void setSource(String source) { this.source = source; }
+    public String getSourceUrl() { return sourceUrl; }
+    public void setSourceUrl(String sourceUrl) { this.sourceUrl = sourceUrl; }
+    public String getUrl() { return url; }
+    public void setUrl(String url) { this.url = url; }
+    public String getImageUrl() { return imageUrl; }
+    public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+    public Instant getPublishedAt() { return publishedAt; }
+    public void setPublishedAt(Instant publishedAt) { this.publishedAt = publishedAt; }
+    public String getDistrict() { return district; }
+    public void setDistrict(String district) { this.district = district; }
+    public String getCategory() { return category; }
+    public void setCategory(String category) { this.category = category; }
+    public boolean isVerified() { return verified; }
+    public void setVerified(boolean verified) { this.verified = verified; }
 }

--- a/backend/src/main/java/com/infora/backend/model/User.java
+++ b/backend/src/main/java/com/infora/backend/model/User.java
@@ -1,20 +1,32 @@
 package com.infora.backend.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.time.Instant;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class User {
     private String id;
     private String name;
     private String email;
     private String preferredLanguage; // "en", "si", "ta"
     private Instant createdAt;
+
+    public User() {}
+
+    public User(String id, String name, String email, String preferredLanguage, Instant createdAt) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.preferredLanguage = preferredLanguage;
+        this.createdAt = createdAt;
+    }
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPreferredLanguage() { return preferredLanguage; }
+    public void setPreferredLanguage(String preferredLanguage) { this.preferredLanguage = preferredLanguage; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
 }

--- a/backend/src/main/java/com/infora/backend/repository/ChatRepository.java
+++ b/backend/src/main/java/com/infora/backend/repository/ChatRepository.java
@@ -3,33 +3,31 @@ package com.infora.backend.repository;
 import com.google.cloud.firestore.*;
 import com.infora.backend.model.ChatSession;
 import com.infora.backend.model.Message;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Repository
-@RequiredArgsConstructor
 public class ChatRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(ChatRepository.class);
 
     private final Firestore firestore;
     private static final String COLLECTION = "chatSessions";
 
+    public ChatRepository(Firestore firestore) {
+        this.firestore = firestore;
+    }
+
     public ChatSession create(String userId, String language) {
         try {
             String sessionId = UUID.randomUUID().toString();
-            ChatSession session = ChatSession.builder()
-                    .id(sessionId)
-                    .userId(userId)
-                    .language(language)
-                    .messages(new ArrayList<>())
-                    .createdAt(Instant.now())
-                    .updatedAt(Instant.now())
-                    .build();
+            ChatSession session = new ChatSession(
+                    sessionId, userId, language, new ArrayList<>(), Instant.now(), Instant.now());
 
             Map<String, Object> data = Map.of(
                     "userId", userId,
@@ -115,26 +113,27 @@ public class ChatRepository {
 
         List<Message> messages = new ArrayList<>();
         if (rawMessages != null) {
-            messages = rawMessages.stream().map(m -> Message.builder()
-                    .role((String) m.get("role"))
-                    .content((String) m.get("content"))
-                    .type((String) m.getOrDefault("type", "text"))
-                    .timestamp(m.get("timestamp") != null
-                            ? Instant.parse((String) m.get("timestamp"))
-                            : Instant.now())
-                    .build()
-            ).collect(Collectors.toList());
+            messages = rawMessages.stream().map(m -> {
+                Message msg = new Message();
+                msg.setRole((String) m.get("role"));
+                msg.setContent((String) m.get("content"));
+                msg.setType((String) m.getOrDefault("type", "text"));
+                msg.setTimestamp(m.get("timestamp") != null
+                        ? Instant.parse((String) m.get("timestamp"))
+                        : Instant.now());
+                return msg;
+            }).collect(Collectors.toList());
         }
 
-        return ChatSession.builder()
-                .id(doc.getId())
-                .userId(doc.getString("userId"))
-                .language(doc.getString("language"))
-                .messages(messages)
-                .createdAt(doc.getString("createdAt") != null
-                        ? Instant.parse(doc.getString("createdAt")) : Instant.now())
-                .updatedAt(doc.getString("updatedAt") != null
-                        ? Instant.parse(doc.getString("updatedAt")) : Instant.now())
-                .build();
+        return new ChatSession(
+                doc.getId(),
+                doc.getString("userId"),
+                doc.getString("language"),
+                messages,
+                doc.getString("createdAt") != null
+                        ? Instant.parse(doc.getString("createdAt")) : Instant.now(),
+                doc.getString("updatedAt") != null
+                        ? Instant.parse(doc.getString("updatedAt")) : Instant.now()
+        );
     }
 }

--- a/backend/src/main/java/com/infora/backend/repository/GovServiceRepository.java
+++ b/backend/src/main/java/com/infora/backend/repository/GovServiceRepository.java
@@ -2,20 +2,24 @@ package com.infora.backend.repository;
 
 import com.google.cloud.firestore.*;
 import com.infora.backend.model.GovService;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Repository
-@RequiredArgsConstructor
 public class GovServiceRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(GovServiceRepository.class);
 
     private final Firestore firestore;
     private static final String COLLECTION = "govServices";
+
+    public GovServiceRepository(Firestore firestore) {
+        this.firestore = firestore;
+    }
 
     @SuppressWarnings("unchecked")
     public List<GovService> findAll() {
@@ -73,22 +77,22 @@ public class GovServiceRepository {
 
     @SuppressWarnings("unchecked")
     private GovService documentToService(DocumentSnapshot doc) {
-        return GovService.builder()
-                .id(doc.getId())
-                .nameEn(doc.getString("name_en"))
-                .nameSi(doc.getString("name_si"))
-                .nameTa(doc.getString("name_ta"))
-                .descriptionEn(doc.getString("description_en"))
-                .descriptionSi(doc.getString("description_si"))
-                .descriptionTa(doc.getString("description_ta"))
-                .icon(doc.getString("icon"))
-                .color(doc.getString("color"))
-                .processingTime(doc.getString("processingTime"))
-                .fee(doc.getString("fee"))
-                .officialSource(doc.getString("officialSource"))
-                .officialUrl(doc.getString("officialUrl"))
-                .documents((List<String>) doc.get("documents"))
-                .steps((List<String>) doc.get("steps"))
-                .build();
+        GovService svc = new GovService();
+        svc.setId(doc.getId());
+        svc.setNameEn(doc.getString("name_en"));
+        svc.setNameSi(doc.getString("name_si"));
+        svc.setNameTa(doc.getString("name_ta"));
+        svc.setDescriptionEn(doc.getString("description_en"));
+        svc.setDescriptionSi(doc.getString("description_si"));
+        svc.setDescriptionTa(doc.getString("description_ta"));
+        svc.setIcon(doc.getString("icon"));
+        svc.setColor(doc.getString("color"));
+        svc.setProcessingTime(doc.getString("processingTime"));
+        svc.setFee(doc.getString("fee"));
+        svc.setOfficialSource(doc.getString("officialSource"));
+        svc.setOfficialUrl(doc.getString("officialUrl"));
+        svc.setDocuments((List<String>) doc.get("documents"));
+        svc.setSteps((List<String>) doc.get("steps"));
+        return svc;
     }
 }

--- a/backend/src/main/java/com/infora/backend/repository/NewsRepository.java
+++ b/backend/src/main/java/com/infora/backend/repository/NewsRepository.java
@@ -2,21 +2,25 @@ package com.infora.backend.repository;
 
 import com.google.cloud.firestore.*;
 import com.infora.backend.model.NewsArticle;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Repository
-@RequiredArgsConstructor
 public class NewsRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(NewsRepository.class);
 
     private final Firestore firestore;
     private static final String COLLECTION = "newsCache";
+
+    public NewsRepository(Firestore firestore) {
+        this.firestore = firestore;
+    }
 
     public NewsArticle save(NewsArticle article) {
         try {
@@ -125,21 +129,21 @@ public class NewsRepository {
     }
 
     private NewsArticle documentToArticle(DocumentSnapshot doc) {
-        return NewsArticle.builder()
-                .id(doc.getId())
-                .titleEn(doc.getString("title_en"))
-                .titleSi(doc.getString("title_si"))
-                .summaryEn(doc.getString("summary_en"))
-                .summarySi(doc.getString("summary_si"))
-                .source(doc.getString("source"))
-                .sourceUrl(doc.getString("sourceUrl"))
-                .url(doc.getString("url"))
-                .imageUrl(doc.getString("imageUrl"))
-                .publishedAt(doc.getString("publishedAt") != null
-                        ? Instant.parse(doc.getString("publishedAt")) : null)
-                .district(doc.getString("district"))
-                .category(doc.getString("category"))
-                .verified(Boolean.TRUE.equals(doc.getBoolean("verified")))
-                .build();
+        NewsArticle article = new NewsArticle();
+        article.setId(doc.getId());
+        article.setTitleEn(doc.getString("title_en"));
+        article.setTitleSi(doc.getString("title_si"));
+        article.setSummaryEn(doc.getString("summary_en"));
+        article.setSummarySi(doc.getString("summary_si"));
+        article.setSource(doc.getString("source"));
+        article.setSourceUrl(doc.getString("sourceUrl"));
+        article.setUrl(doc.getString("url"));
+        article.setImageUrl(doc.getString("imageUrl"));
+        article.setPublishedAt(doc.getString("publishedAt") != null
+                ? Instant.parse(doc.getString("publishedAt")) : null);
+        article.setDistrict(doc.getString("district"));
+        article.setCategory(doc.getString("category"));
+        article.setVerified(Boolean.TRUE.equals(doc.getBoolean("verified")));
+        return article;
     }
 }

--- a/backend/src/main/java/com/infora/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/infora/backend/repository/UserRepository.java
@@ -3,21 +3,25 @@ package com.infora.backend.repository;
 import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.*;
 import com.infora.backend.model.User;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 
-@Slf4j
 @Repository
-@RequiredArgsConstructor
 public class UserRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(UserRepository.class);
 
     private final Firestore firestore;
     private static final String COLLECTION = "users";
+
+    public UserRepository(Firestore firestore) {
+        this.firestore = firestore;
+    }
 
     public User save(String userId, User user) {
         try {
@@ -73,14 +77,14 @@ public class UserRepository {
     }
 
     private User documentToUser(DocumentSnapshot doc) {
-        return User.builder()
-                .id(doc.getId())
-                .name(doc.getString("name"))
-                .email(doc.getString("email"))
-                .preferredLanguage(doc.getString("preferredLanguage"))
-                .createdAt(doc.getString("createdAt") != null
+        return new User(
+                doc.getId(),
+                doc.getString("name"),
+                doc.getString("email"),
+                doc.getString("preferredLanguage"),
+                doc.getString("createdAt") != null
                         ? Instant.parse(doc.getString("createdAt"))
-                        : Instant.now())
-                .build();
+                        : Instant.now()
+        );
     }
 }

--- a/backend/src/main/java/com/infora/backend/service/ChatService.java
+++ b/backend/src/main/java/com/infora/backend/service/ChatService.java
@@ -7,8 +7,8 @@ import com.infora.backend.model.Message;
 import com.infora.backend.model.NewsArticle;
 import com.infora.backend.model.GovService;
 import com.infora.backend.repository.ChatRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -23,14 +23,20 @@ import java.util.stream.Collectors;
  * In production, this integrates with Rasa NLP for proper
  * intent classification and entity extraction.
  */
-@Slf4j
 @Service
-@RequiredArgsConstructor
 public class ChatService {
+
+    private static final Logger log = LoggerFactory.getLogger(ChatService.class);
 
     private final ChatRepository chatRepository;
     private final NewsService newsService;
     private final GovServiceService govServiceService;
+
+    public ChatService(ChatRepository chatRepository, NewsService newsService, GovServiceService govServiceService) {
+        this.chatRepository = chatRepository;
+        this.newsService = newsService;
+        this.govServiceService = govServiceService;
+    }
 
     public ChatResponse processMessage(String userId, ChatRequest request) {
         // Get or create session
@@ -43,12 +49,11 @@ public class ChatService {
         }
 
         // Save user message
-        Message userMsg = Message.builder()
-                .role("user")
-                .content(request.getMessage())
-                .type("text")
-                .timestamp(Instant.now())
-                .build();
+        Message userMsg = new Message();
+        userMsg.setRole("user");
+        userMsg.setContent(request.getMessage());
+        userMsg.setType("text");
+        userMsg.setTimestamp(Instant.now());
         chatRepository.addMessage(session.getId(), userMsg);
 
         // Process intent and generate response
@@ -57,12 +62,11 @@ public class ChatService {
         response.setSessionId(session.getId());
 
         // Save assistant response
-        Message assistantMsg = Message.builder()
-                .role("assistant")
-                .content(response.getReply().getContent())
-                .type(response.getCards() != null && !response.getCards().isEmpty() ? "card" : "text")
-                .timestamp(Instant.now())
-                .build();
+        Message assistantMsg = new Message();
+        assistantMsg.setRole("assistant");
+        assistantMsg.setContent(response.getReply().getContent());
+        assistantMsg.setType(response.getCards() != null && !response.getCards().isEmpty() ? "card" : "text");
+        assistantMsg.setTimestamp(Instant.now());
         chatRepository.addMessage(session.getId(), assistantMsg);
 
         return response;
@@ -99,23 +103,25 @@ public class ChatService {
             List<NewsArticle> articles = newsService.getLatestNews(3);
             if (!articles.isEmpty()) {
                 cards = articles.stream()
-                        .map(a -> ChatResponse.ResponseCard.builder()
-                                .title(a.getTitleEn() != null ? a.getTitleEn() : "News Article")
-                                .description(a.getSummaryEn() != null ? a.getSummaryEn() : "")
-                                .type("news")
-                                .source(a.getSource())
-                                .sourceUrl(a.getSourceUrl())
-                                .verified(a.isVerified())
-                                .build())
+                        .map(a -> {
+                            ChatResponse.ResponseCard card = new ChatResponse.ResponseCard();
+                            card.setTitle(a.getTitleEn() != null ? a.getTitleEn() : "News Article");
+                            card.setDescription(a.getSummaryEn() != null ? a.getSummaryEn() : "");
+                            card.setType("news");
+                            card.setSource(a.getSource());
+                            card.setSourceUrl(a.getSourceUrl());
+                            card.setVerified(a.isVerified());
+                            return card;
+                        })
                         .collect(Collectors.toList());
             } else {
-                cards.add(ChatResponse.ResponseCard.builder()
-                        .title("Latest Sri Lankan News")
-                        .description("Check verified sources: Ada Derana, Daily Mirror, NewsFirst")
-                        .type("news")
-                        .source("Multiple Sources")
-                        .verified(true)
-                        .build());
+                ChatResponse.ResponseCard card = new ChatResponse.ResponseCard();
+                card.setTitle("Latest Sri Lankan News");
+                card.setDescription("Check verified sources: Ada Derana, Daily Mirror, NewsFirst");
+                card.setType("news");
+                card.setSource("Multiple Sources");
+                card.setVerified(true);
+                cards.add(card);
             }
 
         } else if (containsPassportIntent(query)) {
@@ -144,25 +150,28 @@ public class ChatService {
                     "I can help you with Sri Lankan news, government services, and general information. Try asking about passports, NIC registration, latest news, or any government service!",
                     "මට ශ්‍රී ලංකාවේ පුවත්, රජයේ සේවා සහ සාමාන්‍ය තොරතුරු සම්බන්ධයෙන් ඔබට උදව් කළ හැකිය.",
                     "இலங்கை செய்திகள், அரசாங்க சேவைகள் மற்றும் பொதுவான தகவல்களில் நான் உங்களுக்கு உதவ முடியும்.");
-            cards.add(ChatResponse.ResponseCard.builder()
-                    .title("Browse News").description("Get the latest headlines from verified Sri Lankan sources.")
-                    .type("info").build());
-            cards.add(ChatResponse.ResponseCard.builder()
-                    .title("Government Services").description("Step-by-step guides for passports, NIC, driving license & more.")
-                    .type("info").build());
+            ChatResponse.ResponseCard card1 = new ChatResponse.ResponseCard();
+            card1.setTitle("Browse News");
+            card1.setDescription("Get the latest headlines from verified Sri Lankan sources.");
+            card1.setType("info");
+            cards.add(card1);
+            ChatResponse.ResponseCard card2 = new ChatResponse.ResponseCard();
+            card2.setTitle("Government Services");
+            card2.setDescription("Step-by-step guides for passports, NIC, driving license & more.");
+            card2.setType("info");
+            cards.add(card2);
         }
 
-        Message reply = Message.builder()
-                .role("assistant")
-                .content(replyText)
-                .type(cards.isEmpty() ? "text" : "card")
-                .timestamp(Instant.now())
-                .build();
+        Message reply = new Message();
+        reply.setRole("assistant");
+        reply.setContent(replyText);
+        reply.setType(cards.isEmpty() ? "text" : "card");
+        reply.setTimestamp(Instant.now());
 
-        return ChatResponse.builder()
-                .reply(reply)
-                .cards(cards)
-                .build();
+        ChatResponse chatResponse = new ChatResponse();
+        chatResponse.setReply(reply);
+        chatResponse.setCards(cards);
+        return chatResponse;
     }
 
     private List<ChatResponse.ResponseCard> getServiceCards(String serviceId) {
@@ -171,24 +180,24 @@ public class ChatService {
             GovService svc = govServiceService.getService(serviceId);
             if (svc.getSteps() != null) {
                 for (int i = 0; i < Math.min(svc.getSteps().size(), 3); i++) {
-                    cards.add(ChatResponse.ResponseCard.builder()
-                            .title("Step " + (i + 1))
-                            .description(svc.getSteps().get(i))
-                            .type("service")
-                            .source(svc.getOfficialSource())
-                            .sourceUrl(svc.getOfficialUrl())
-                            .verified(true)
-                            .build());
+                    ChatResponse.ResponseCard card = new ChatResponse.ResponseCard();
+                    card.setTitle("Step " + (i + 1));
+                    card.setDescription(svc.getSteps().get(i));
+                    card.setType("service");
+                    card.setSource(svc.getOfficialSource());
+                    card.setSourceUrl(svc.getOfficialUrl());
+                    card.setVerified(true);
+                    cards.add(card);
                 }
             }
         } catch (Exception e) {
             log.warn("Service not found in DB, using fallback: {}", serviceId);
-            cards.add(ChatResponse.ResponseCard.builder()
-                    .title("Service Guide")
-                    .description("Visit the official government website for detailed instructions.")
-                    .type("service")
-                    .verified(true)
-                    .build());
+            ChatResponse.ResponseCard card = new ChatResponse.ResponseCard();
+            card.setTitle("Service Guide");
+            card.setDescription("Visit the official government website for detailed instructions.");
+            card.setType("service");
+            card.setVerified(true);
+            cards.add(card);
         }
         return cards;
     }

--- a/backend/src/main/java/com/infora/backend/service/GovServiceService.java
+++ b/backend/src/main/java/com/infora/backend/service/GovServiceService.java
@@ -3,18 +3,22 @@ package com.infora.backend.service;
 import com.infora.backend.exception.ResourceNotFoundException;
 import com.infora.backend.model.GovService;
 import com.infora.backend.repository.GovServiceRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Slf4j
 @Service
-@RequiredArgsConstructor
 public class GovServiceService {
 
+    private static final Logger log = LoggerFactory.getLogger(GovServiceService.class);
+
     private final GovServiceRepository govServiceRepository;
+
+    public GovServiceService(GovServiceRepository govServiceRepository) {
+        this.govServiceRepository = govServiceRepository;
+    }
 
     public List<GovService> getAllServices() {
         return govServiceRepository.findAll();

--- a/backend/src/main/java/com/infora/backend/service/NewsScraperService.java
+++ b/backend/src/main/java/com/infora/backend/service/NewsScraperService.java
@@ -3,11 +3,11 @@ package com.infora.backend.service;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.infora.backend.model.NewsArticle;
 import com.infora.backend.repository.NewsRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -20,12 +20,16 @@ import java.util.concurrent.TimeUnit;
  * Scheduled service that scrapes RSS feeds from verified Sri Lankan news sources,
  * parses the XML, and stores articles in Firestore.
  */
-@Slf4j
 @Service
-@RequiredArgsConstructor
 public class NewsScraperService {
 
+    private static final Logger log = LoggerFactory.getLogger(NewsScraperService.class);
+
     private final NewsRepository newsRepository;
+
+    public NewsScraperService(NewsRepository newsRepository) {
+        this.newsRepository = newsRepository;
+    }
 
     @Value("${news.sources.ada-derana:https://www.adaderana.lk/rss.php}")
     private String adaDeranaUrl;
@@ -34,21 +38,24 @@ public class NewsScraperService {
     private String dailyMirrorUrl;
 
     private final OkHttpClient httpClient = new OkHttpClient.Builder()
-            .connectTimeout(10, TimeUnit.SECONDS)
-            .readTimeout(15, TimeUnit.SECONDS)
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .followRedirects(true)
             .build();
+
+    private final XmlMapper xmlMapper = new XmlMapper();
 
     /**
      * Runs every 15 minutes to fetch latest news articles.
-     * Configurable via application.properties.
+     * Initial delay of 10 seconds to let the app fully start.
      */
-    @Scheduled(fixedRateString = "${news.scraper.interval:900000}")
+    @Scheduled(fixedRateString = "${news.scraper.interval:900000}", initialDelay = 10000)
     public void scrapeAllSources() {
         log.info("Starting news scrape cycle...");
         int total = 0;
         total += scrapeRssFeed("Ada Derana", adaDeranaUrl, "https://www.adaderana.lk");
         total += scrapeRssFeed("Daily Mirror", dailyMirrorUrl, "https://www.dailymirror.lk");
-        log.info("News scrape cycle complete. Total articles processed: {}", total);
+        log.info("News scrape cycle complete. Total articles saved: {}", total);
     }
 
     @SuppressWarnings("unchecked")
@@ -56,7 +63,8 @@ public class NewsScraperService {
         try {
             Request request = new Request.Builder()
                     .url(feedUrl)
-                    .header("User-Agent", "Infora-NewsBot/1.0")
+                    .header("User-Agent", "Mozilla/5.0 (compatible; Infora-NewsBot/1.0)")
+                    .header("Accept", "application/rss+xml, application/xml, text/xml, */*")
                     .build();
 
             try (Response response = httpClient.newCall(request).execute()) {
@@ -66,8 +74,33 @@ public class NewsScraperService {
                 }
 
                 String xml = response.body().string();
-                XmlMapper xmlMapper = new XmlMapper();
-                Map<String, Object> rss = xmlMapper.readValue(xml, Map.class);
+
+                // Clean common XML issues
+                xml = xml.trim();
+                if (xml.startsWith("\uFEFF")) {
+                    xml = xml.substring(1); // Remove BOM
+                }
+
+                // Try to parse as RSS
+                Map<String, Object> rss;
+                try {
+                    rss = xmlMapper.readValue(xml, Map.class);
+                } catch (Exception parseEx) {
+                    // Try removing problematic characters before the XML declaration
+                    int xmlStart = xml.indexOf("<?xml");
+                    if (xmlStart > 0) {
+                        xml = xml.substring(xmlStart);
+                        try {
+                            rss = xmlMapper.readValue(xml, Map.class);
+                        } catch (Exception e2) {
+                            log.warn("Cannot parse RSS from {}: {}", sourceName, e2.getMessage());
+                            return 0;
+                        }
+                    } else {
+                        log.warn("Cannot parse RSS from {}: {}", sourceName, parseEx.getMessage());
+                        return 0;
+                    }
+                }
 
                 Object channelObj = rss.get("channel");
                 if (channelObj == null) {
@@ -77,13 +110,19 @@ public class NewsScraperService {
 
                 Map<String, Object> channel = (Map<String, Object>) channelObj;
                 Object itemsObj = channel.get("item");
-                if (itemsObj == null) return 0;
+                if (itemsObj == null) {
+                    log.warn("No items found in RSS from {}", sourceName);
+                    return 0;
+                }
 
                 List<Map<String, Object>> items;
                 if (itemsObj instanceof List) {
                     items = (List<Map<String, Object>>) itemsObj;
-                } else {
+                } else if (itemsObj instanceof Map) {
                     items = List.of((Map<String, Object>) itemsObj);
+                } else {
+                    log.warn("Unexpected items format in RSS from {}", sourceName);
+                    return 0;
                 }
 
                 int count = 0;
@@ -98,28 +137,32 @@ public class NewsScraperService {
                         // Clean HTML from description
                         if (description != null) {
                             description = description.replaceAll("<[^>]*>", "").trim();
+                            description = description.replaceAll("&amp;", "&")
+                                    .replaceAll("&lt;", "<")
+                                    .replaceAll("&gt;", ">")
+                                    .replaceAll("&quot;", "\"")
+                                    .replaceAll("&#39;", "'");
                             if (description.length() > 300) {
                                 description = description.substring(0, 297) + "...";
                             }
                         }
 
-                        NewsArticle article = NewsArticle.builder()
-                                .id(generateArticleId(sourceName, title))
-                                .titleEn(title)
-                                .summaryEn(description)
-                                .source(sourceName)
-                                .sourceUrl(sourceUrl)
-                                .url(link)
-                                .category(categorizeArticle(title))
-                                .district("Colombo")
-                                .publishedAt(Instant.now())
-                                .verified(true)
-                                .build();
+                        NewsArticle article = new NewsArticle();
+                        article.setId(generateArticleId(sourceName, title));
+                        article.setTitleEn(title.trim());
+                        article.setSummaryEn(description);
+                        article.setSource(sourceName);
+                        article.setSourceUrl(sourceUrl);
+                        article.setUrl(link);
+                        article.setCategory(categorizeArticle(title));
+                        article.setDistrict("Colombo");
+                        article.setPublishedAt(Instant.now());
+                        article.setVerified(true);
 
                         newsRepository.save(article);
                         count++;
                     } catch (Exception e) {
-                        log.debug("Skipping malformed item from {}", sourceName);
+                        log.debug("Skipping item from {}: {}", sourceName, e.getMessage());
                     }
                 }
 
@@ -134,7 +177,19 @@ public class NewsScraperService {
 
     private String getStringValue(Map<String, Object> map, String key) {
         Object val = map.get(key);
-        return val != null ? val.toString() : null;
+        if (val == null) return null;
+        if (val instanceof String) return (String) val;
+        if (val instanceof Map) {
+            // Some RSS feeds wrap text in nested elements
+            Map<?, ?> nested = (Map<?, ?>) val;
+            Object content = nested.get("");
+            if (content != null) return content.toString();
+            // Try getting first value
+            for (Object v : nested.values()) {
+                if (v instanceof String) return (String) v;
+            }
+        }
+        return val.toString();
     }
 
     private String generateArticleId(String source, String title) {
@@ -143,22 +198,23 @@ public class NewsScraperService {
     }
 
     /**
-     * Basic keyword-based categorization. In production, use NLP classification.
+     * Basic keyword-based categorization.
      */
     private String categorizeArticle(String title) {
         String t = title.toLowerCase();
         if (t.contains("parliament") || t.contains("minister") || t.contains("election") ||
-            t.contains("president") || t.contains("government")) return "politics";
+            t.contains("president") || t.contains("government") || t.contains("mp ") ||
+            t.contains("cabinet") || t.contains("opposition")) return "politics";
         if (t.contains("economy") || t.contains("bank") || t.contains("rupee") ||
-            t.contains("export") || t.contains("gdp") || t.contains("inflation")) return "economy";
+            t.contains("export") || t.contains("gdp") || t.contains("inflation") ||
+            t.contains("tax") || t.contains("budget") || t.contains("revenue")) return "economy";
         if (t.contains("cricket") || t.contains("sport") || t.contains("rugby") ||
-            t.contains("olympics") || t.contains("match")) return "sports";
+            t.contains("olympics") || t.contains("match") || t.contains("football")) return "sports";
         if (t.contains("tech") || t.contains("digital") || t.contains("software") ||
-            t.contains("internet") || t.contains("ai")) return "technology";
-        if (t.contains("colombo") || t.contains("kandy") || t.contains("galle") ||
-            t.contains("jaffna") || t.contains("district")) return "local";
+            t.contains("internet") || t.contains("ai") || t.contains("startup")) return "technology";
         if (t.contains("india") || t.contains("china") || t.contains("us ") ||
-            t.contains("world") || t.contains("global")) return "international";
+            t.contains("world") || t.contains("global") || t.contains("un ") ||
+            t.contains("russia") || t.contains("ukraine")) return "international";
         return "local";
     }
 }

--- a/backend/src/main/java/com/infora/backend/service/NewsService.java
+++ b/backend/src/main/java/com/infora/backend/service/NewsService.java
@@ -2,19 +2,23 @@ package com.infora.backend.service;
 
 import com.infora.backend.model.NewsArticle;
 import com.infora.backend.repository.NewsRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 
-@Slf4j
 @Service
-@RequiredArgsConstructor
 public class NewsService {
 
+    private static final Logger log = LoggerFactory.getLogger(NewsService.class);
+
     private final NewsRepository newsRepository;
+
+    public NewsService(NewsRepository newsRepository) {
+        this.newsRepository = newsRepository;
+    }
 
     public List<NewsArticle> getLatestNews(int limit) {
         return newsRepository.findAll(Math.min(limit, 50));

--- a/backend/src/main/java/com/infora/backend/service/UserService.java
+++ b/backend/src/main/java/com/infora/backend/service/UserService.java
@@ -4,23 +4,26 @@ import com.infora.backend.dto.UserRequest;
 import com.infora.backend.exception.ResourceNotFoundException;
 import com.infora.backend.model.User;
 import com.infora.backend.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
-@RequiredArgsConstructor
 public class UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
     private final UserRepository userRepository;
 
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
     public User createOrUpdate(String userId, UserRequest request) {
-        User user = User.builder()
-                .name(request.getName())
-                .email(request.getEmail())
-                .preferredLanguage(request.getPreferredLanguage())
-                .build();
+        User user = new User();
+        user.setName(request.getName());
+        user.setEmail(request.getEmail());
+        user.setPreferredLanguage(request.getPreferredLanguage());
         return userRepository.save(userId, user);
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -42,9 +42,9 @@ rasa.server.read-timeout=10000
 
 # ─── News Sources (RSS feeds for scraping) ───
 news.sources.ada-derana=https://www.adaderana.lk/rss.php
-news.sources.daily-mirror=https://www.dailymirror.lk/rss
+news.sources.daily-mirror=https://www.dailymirror.lk/RSS/Main
 news.sources.hiru-news=https://www.hirunews.lk/rss
-news.sources.esana=https://esana.lk/rss
+news.sources.newsfirst=https://www.newsfirst.lk/feed/
 
 # ─── API Base URL (for frontend clients) ───
 api.base-url=http://localhost:8080/api/v1


### PR DESCRIPTION
Replace Lombok usage across the backend with explicit constructors, getters/setters and no-arg constructors for DTOs, models and response classes; update controllers, repositories and services to use explicit constructor injection (removed @RequiredArgsConstructor) and switch logging to LoggerFactory. Adjust repository/model code to stop using builders and handle Firestore mapping with setters/constructors. Update FirebaseConfig to clean up stale FirebaseApp instances (handles DevTools restarts) and make FirebaseAuthFilter use explicit constructor + Logger. SecurityConfig now uses an injected CorsConfigurationSource. Bump project Java version to 21 and switch build plugins: configure maven-compiler-plugin source/target and add spring-boot-maven-plugin. Small frontend import/order/UI tweak in chat page.